### PR TITLE
Fix for looks without workspace names

### DIFF
--- a/i3-next-workspace
+++ b/i3-next-workspace
@@ -28,9 +28,14 @@ if __name__ == "__main__":
             if re.search("^i3-wm\.workspace\...\.name:",line)
             ]
     mapping_names = {
-            int(line.split(":")[0]) : line.split(":")[1]
+        int(line.split(":")[0]) : line.split(":")[1]
+        for line in output if ':' in line
+    }
+    if not mapping_names:
+        mapping_names = {
+            int(line) : line
             for line in output
-            }
+        }   
 
     startnum = min(mapping_names.keys())
     endnum = 50

--- a/i3-next-workspace
+++ b/i3-next-workspace
@@ -27,15 +27,13 @@ if __name__ == "__main__":
             for line in output 
             if re.search("^i3-wm\.workspace\...\.name:",line)
             ]
-    mapping_names = {
-        int(line.split(":")[0]) : line.split(":")[1]
-        for line in output if ':' in line
-    }
-    if not mapping_names:
-        mapping_names = {
-            int(line) : line
-            for line in output
-        }   
+    mapping_names = {}
+    for line in output:
+        if ":" in line:
+            key, value = line.split(":")
+            mapping_names[int(key)] = value
+        else:
+            mapping_names[int(line)] = line
 
     startnum = min(mapping_names.keys())
     endnum = 50


### PR DESCRIPTION
# Notes

In Regolith 2.2, there is some simplification to some looks that do not have fancy workspace decorations in the bar.  Rather than pango markup for spacing the index number is used.  This however causes problems with `i3-next-workspace` as it assumes that each workspace label will contain a `:` character which is used in split.  With looks without pango markup the script errors out with an array index bounds error.

I don't think it is a very clean way of fixing the bug, but list comprehension syntax in Python is new to me.  Open to cleaner approaches..

# Testing done

Using looks with the following two Xresources, verify the update moves to a new workspace upon invocation:

```
$ xrdb -query | grep ^i3-wm\.workspace\...\.name:
i3-wm.workspace.01.name:	1
i3-wm.workspace.02.name:	2
i3-wm.workspace.03.name:	3
i3-wm.workspace.04.name:	4
...
```

```
$ xrdb -query | grep ^i3-wm\.workspace\...\.name:
i3-wm.workspace.01.name:	1:<span> </span>1 <span foreground='#478ACC'></span><span> </span>
i3-wm.workspace.02.name:	2:<span> </span>2 <span foreground='#4CBF99'></span><span> </span>
i3-wm.workspace.03.name:	3:<span> </span>3 <span foreground='#86B300'></span><span> </span>
...
```
