### PR TITLE
Relax search on workspace name to work with Regolith 3.0

### DIFF
--- a/i3-next-workspace
+++ b/i3-next-workspace
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     output = [
             line.split("\t")[1] 
             for line in output 
-            if re.search("^i3-wm\.workspace\...\.name:",line)
+            if re.search("wm\.workspace\...\.name:",line)
             ]
     mapping_names = {}
     for line in output:


### PR DESCRIPTION
This change should be backwards compatible with previous Regolith versions.  I do not expect that the relaxation of the search expresion will result in false positives.

Testing done:
* local edit to running version of script, verified change fixed issue