### PR TITLE
fix: workspace regex

### DIFF
--- a/i3-next-workspace
+++ b/i3-next-workspace
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     output = [
             line.split("\t")[1] 
             for line in output 
-            if re.search("wm\.workspace\...\.name:",line)
+            if re.search(r"wm\.workspace\...\.name:",line)
             ]
     mapping_names = {}
     for line in output:


### PR DESCRIPTION
The regex has an invalid escape sequence now. Turn the string in to a raw string.